### PR TITLE
Add missing binarySlice/binaryWrite methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ SlowBuffer.byteLength = function (str, encoding) {
       return utf8ToBytes(str).length;
 
     case 'ascii':
+    case 'binary':
       return str.length;
 
     case 'base64':
@@ -80,6 +81,8 @@ SlowBuffer.prototype.asciiWrite = function (string, offset, length) {
   var bytes, pos;
   return SlowBuffer._charsWritten =  blitBuffer(asciiToBytes(string), this, offset, length);
 };
+
+SlowBuffer.prototype.binaryWrite = SlowBuffer.prototype.asciiWrite;
 
 SlowBuffer.prototype.base64Write = function (string, offset, length) {
   var bytes, pos;
@@ -124,6 +127,8 @@ SlowBuffer.prototype.asciiSlice = function () {
     ret += String.fromCharCode(bytes[i]);
   return ret;
 }
+
+SlowBuffer.prototype.binarySlice = SlowBuffer.prototype.asciiSlice;
 
 SlowBuffer.prototype.inspect = function() {
   var out = [],

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -19,6 +19,15 @@ test('utf8 buffer to hex', function (t) {
     t.end();
 });
 
+test('utf8 to utf8', function (t) {
+    t.plan(1);
+    t.equal(
+        new buffer.Buffer("öäüõÖÄÜÕ", "utf8").toString("utf8"),
+        new Buffer("öäüõÖÄÜÕ", "utf8").toString("utf8")
+    );
+    t.end();
+});
+
 test('ascii buffer to base64', function (t) {
     t.plan(1);
     t.equal(
@@ -69,6 +78,43 @@ test('hex buffer to ascii', function (t) {
     t.equal(
         new buffer.Buffer("31323334353621402324255e", "hex").toString("ascii"),
         new Buffer("31323334353621402324255e", "hex").toString("ascii")
+    );
+    t.end();
+});
+/*
+test('utf8 to ascii', function (t) {
+    t.plan(1);
+    t.equal(
+        new buffer.Buffer("öäüõÖÄÜÕ", "utf8").toString("ascii"),
+        new Buffer("öäüõÖÄÜÕ", "utf8").toString("ascii")
+    );
+    t.end();
+});
+*/
+
+test('base64 buffer to binary', function (t) {
+    t.plan(1);
+    t.equal(
+        new buffer.Buffer("MTIzNDU2IUAjJCVe", "base64").toString("binary"),
+        new Buffer("MTIzNDU2IUAjJCVe", "base64").toString("binary")
+    );
+    t.end();
+});
+
+test('hex buffer to binary', function (t) {
+    t.plan(1);
+    t.equal(
+        new buffer.Buffer("31323334353621402324255e", "hex").toString("binary"),
+        new Buffer("31323334353621402324255e", "hex").toString("binary")
+    );
+    t.end();
+});
+
+test('utf8 to binary', function (t) {
+    t.plan(1);
+    t.equal(
+        new buffer.Buffer("öäüõÖÄÜÕ", "utf8").toString("binary"),
+        new Buffer("öäüõÖÄÜÕ", "utf8").toString("binary")
     );
     t.end();
 });


### PR DESCRIPTION
`binarySlice()` and `binaryWrite()` are referenced from the code but such methods don't exist. Seems that current ascii implementation is actually same that node uses for binary.

I didn't change the ascii behavior but it's not quite the same that node uses(see commented in testcase).
