### PR TITLE
Allow creating buffers from buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,7 +359,12 @@ function Buffer(subject, encoding, offset) {
     // Treat array-ish objects as a byte array.
     if (isArrayIsh(subject)) {
       for (var i = 0; i < this.length; i++) {
-        this.parent[i + this.offset] = subject[i];
+        if (subject instanceof Buffer) {
+          this.parent[i + this.offset] = subject.readUInt8(i);
+        }
+        else {
+          this.parent[i + this.offset] = subject[i];
+        }
       }
     } else if (type == 'string') {
       // We are a string

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -119,3 +119,11 @@ test("concat() a varying number of buffers", function (t) {
     t.equal(flatLongLen.toString(), (new Array(10+1).join('asdf')));
     t.end();
 });
+
+test("buffer from buffer", function (t) {
+    t.plan(1);
+    var b1 = new buffer.Buffer('asdf');
+    var b2 = new buffer.Buffer(b1);
+    t.equal(b1.toString('hex'), b2.toString('hex'));
+    t.end();
+});


### PR DESCRIPTION
Its quite common to create a buffer from buffer(clone) but it doesn't currently work in buffer-browserify because elements can't be accessed by indexes.
