### PR TITLE
Add support for fill()

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,6 +300,19 @@ SlowBuffer.prototype.copy = function(target, targetstart, sourcestart, sourceend
   }
 };
 
+SlowBuffer.prototype.fill = function(value, start, end) {
+  if (end > this.length) {
+    throw new Error('oob');
+  }
+  if (start > end) {
+    throw new Error('oob');
+  }
+
+  for (var i = start; i < end; i++) {
+    this[i] = value;
+  }
+}
+
 function coerce(length) {
   // Coerce length to a number (possibly NaN), round up
   // in case it's fractional (e.g. 123.456) then do a

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -119,3 +119,13 @@ test("concat() a varying number of buffers", function (t) {
     t.equal(flatLongLen.toString(), (new Array(10+1).join('asdf')));
     t.end();
 });
+
+test("fill", function(t) {
+    t.plan(1);
+    var b1 = new Buffer(10);
+    var b2 = new buffer.Buffer(10);
+    b1.fill(2);
+    b2.fill(2);
+    t.equal(b1.toString('hex'), b2.toString('hex'));
+    t.end();
+})


### PR DESCRIPTION
`fill()` is referenced from code but not implemented.
