### PR TITLE
Fix: buffer.copy ignores sourceEnd if it's set to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,9 @@ Buffer.prototype.slice = function(start, end) {
 Buffer.prototype.copy = function(target, target_start, start, end) {
   var source = this;
   start || (start = 0);
-  end || (end = this.length);
+  if (end === undefined || isNaN(end)) {
+    end = this.length;
+  }
   target_start || (target_start = 0);
 
   if (end < start) throw new Error('sourceEnd < sourceStart');

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -223,3 +223,12 @@ test("fill", function(t) {
     t.equal(b.toString('hex'), '02020202020202020202');
     t.end();
 });
+
+test('copy() empty buffer with sourceEnd=0', function (t) {
+    t.plan(1);
+    var source = new B([42]);
+    var destination = new B([43]);
+    source.copy(destination, 0, 0, 0);
+    t.equal(destination.readUInt8(0), 43);
+    t.end();
+});


### PR DESCRIPTION
At the moment, buffer.copy treats `sourceEnd`=0 as if it's undefined, meaning it gets set to `this.length`. It should just leave the value as 0.
