### PR TITLE
IE6 support, and ES5 assumptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,7 +385,7 @@ Buffer.isBuffer = function isBuffer(b) {
 };
 
 Buffer.concat = function (list, totalLength) {
-  if (!Array.isArray(list)) {
+  if (!isArray(list)) {
     throw new Error("Usage: Buffer.concat(list, [totalLength])\n \
       list should be an Array.");
   }
@@ -424,8 +424,16 @@ function coerce(length) {
   return length < 0 ? 0 : length;
 }
 
+function isArray(subject) {
+  return (Array.isArray ||
+    function(subject){
+      return {}.toString.apply(subject) == '[object Array]'
+    })
+    (subject)
+}
+
 function isArrayIsh(subject) {
-  return Array.isArray(subject) || Buffer.isBuffer(subject) ||
+  return isArray(subject) || Buffer.isBuffer(subject) ||
          subject && typeof subject === 'object' &&
          typeof subject.length === 'number';
 }


### PR DESCRIPTION
I don't know if compatibility is a target of these browserify modules … but currently, IE6 bugs out with “Object doesn't support this property or method.”

This is coming, at the very least, from calls to `.isArray()`, which is ES5, and not available in IE6. There's probably other ES5 / IE6 bugs, as well. I can probably clean these up for you, _if_ backwards-compatibility is something you're willing to sign-on for and maintain? (Also, same question applies to other Browserify projects.)

It will most likely require including some ES5 shims, which will add weight to everything …
