### PR TITLE
avoid circular dependency with assert module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ Buffer.poolSize = 8192;
 exports.INSPECT_MAX_BYTES = 50;
 
 function Buffer(subject, encoding, offset) {
-  if(!assert) assert== require('assert');
+  if(!assert) assert= require('assert');
   if (!(this instanceof Buffer)) {
     return new Buffer(subject, encoding, offset);
   }


### PR DESCRIPTION
Populating the assert on first use to avoid a circular dependency issue with assert.
