### PR TITLE
ignore whitespace. more compatible with node.js Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -470,7 +470,7 @@ function asciiToBytes(str) {
 }
 
 function base64ToBytes(str) {
-  return require("base64-js").toByteArray(str);
+  return require("base64-js").toByteArray(str.trim());
 }
 
 function blitBuffer(src, dst, offset, length) {

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -232,3 +232,11 @@ test('copy() empty buffer with sourceEnd=0', function (t) {
     t.equal(destination.readUInt8(0), 43);
     t.end();
 });
+
+test('base64 ignore whitespace', function(t) {
+  t.plan(1);
+  var text = "\n   YW9ldQ==  ";
+  var buf = new B(text, 'base64');
+  t.equal(buf.toString(), 'aoeu');
+  t.end();
+});


### PR DESCRIPTION
`trim` is available in [every browser that matters](http://kangax.github.io/es5-compat-table/)
