### PR TITLE
Remove reserved keywords

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,9 +245,9 @@ Buffer.prototype.hexWrite = function(string, offset, length) {
     length = strLen / 2;
   }
   for (var i = 0; i < length; i++) {
-    var byte = parseInt(string.substr(i * 2, 2), 16);
-    if (isNaN(byte)) throw new Error('Invalid hex string');
-    this[offset + i] = byte;
+    var b = parseInt(string.substr(i * 2, 2), 16);
+    if (isNaN(b)) throw new Error('Invalid hex string');
+    this[offset + i] = b;
   }
   Buffer._charsWritten = i * 2;
   return i;


### PR DESCRIPTION
"byte" is a reserved keyword in JavaScript. Having it in this module
means that the Google Closure compiler will not work on this code.

This patch replaces the usage of byte (which was reserved to one local
funtion) with a non-keyword.
