### PR TITLE
Update base64-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test" : "test"
     },
     "dependencies" : {
-        "base64-js" : "0.0.2"
+        "base64-js" : "0.0.8"
     },
     "devDependencies" : {
         "tape" : "~2.1.0",


### PR DESCRIPTION
This pull request simply updates the version of the `base64-js` module.

I care about this because the current version of `base64-js` includes license info in the `package.json` file, and older versions do not.
